### PR TITLE
dbeaver/pro#3407 Fix AbstractJdbcResultSet.getBigDecimal(int) to handle empty strings

### DIFF
--- a/modules/com.dbeaver.jdbc.api/src/com/dbeaver/jdbc/model/AbstractJdbcResultSet.java
+++ b/modules/com.dbeaver.jdbc.api/src/com/dbeaver/jdbc/model/AbstractJdbcResultSet.java
@@ -619,7 +619,7 @@ public abstract class AbstractJdbcResultSet<
     @Override
     public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
         final String value = getString(columnIndex);
-        if (value == null || value.trim().isEmpty()) {
+        if (value == null || value.isBlank()) {
             return null;
         }
 

--- a/modules/com.dbeaver.jdbc.api/src/com/dbeaver/jdbc/model/AbstractJdbcResultSet.java
+++ b/modules/com.dbeaver.jdbc.api/src/com/dbeaver/jdbc/model/AbstractJdbcResultSet.java
@@ -619,7 +619,11 @@ public abstract class AbstractJdbcResultSet<
     @Override
     public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
         final String value = getString(columnIndex);
-        return value != null ? new BigDecimal(value) : null;
+        if (value == null || value.trim().isEmpty()) {
+            return null;
+        }
+
+        return new BigDecimal(value);
     }
 
     @Override


### PR DESCRIPTION
Ensure `getBigDecimal(int)` checks for empty strings before processing to avoid potential errors.