### PR TITLE
dbeaver/pro#10477 Optimize bundle dependencies

### DIFF
--- a/modules/com.dbeaver.jdbc.api/META-INF/MANIFEST.MF
+++ b/modules/com.dbeaver.jdbc.api/META-INF/MANIFEST.MF
@@ -7,6 +7,6 @@ Bundle-Version: 2.8.0.qualifier
 Bundle-Release-Date: 20240205
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.jkiss.utils
+Require-Bundle: org.jkiss.utils;visibility:=reexport
 Export-Package: com.dbeaver.jdbc.model
 Automatic-Module-Name: com.dbeaver.jdbc.api

--- a/modules/com.dbeaver.rest.client/META-INF/MANIFEST.MF
+++ b/modules/com.dbeaver.rest.client/META-INF/MANIFEST.MF
@@ -7,8 +7,7 @@ Bundle-Version: 2.8.0.qualifier
 Bundle-Release-Date: 20260703
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.jkiss.utils,
- com.google.gson;visibility:=reexport
+Require-Bundle: org.jkiss.utils;visibility:=reexport
 Export-Package: com.dbeaver.rest.client,
  com.dbeaver.rest.client.interceptor
 Automatic-Module-Name: com.dbeaver.rest.client

--- a/modules/com.dbeaver.servlet.api/META-INF/MANIFEST.MF
+++ b/modules/com.dbeaver.servlet.api/META-INF/MANIFEST.MF
@@ -7,8 +7,7 @@ Bundle-Version: 2.8.0.qualifier
 Bundle-Release-Date: 20250521
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.jkiss.utils,
- jakarta.servlet-api;bundle-version="6.1.0",
- com.google.gson
+Require-Bundle: org.jkiss.utils;visibility:=reexport,
+ jakarta.servlet-api;visibility:=reexport
 Export-Package: com.dbeaver.servlet.model
 Automatic-Module-Name: com.dbeaver.servlet.api

--- a/modules/org.jkiss.utils/META-INF/MANIFEST.MF
+++ b/modules/org.jkiss.utils/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 2.8.0.qualifier
 Bundle-Release-Date: 20240205
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
-Require-Bundle: com.google.gson
+Require-Bundle: com.google.gson;visibility:=reexport
 Export-Package: org.jkiss.api,
  org.jkiss.api.verification,
  org.jkiss.code,


### PR DESCRIPTION
Closes dbeaver/pro#10477

## Summary
- remove redundant OSGi bundle requirements
- re-export dependencies exposed through bundle APIs

## Testing
- `.\mvnw.cmd verify`
- `git diff --check`

This PR was generated with AI assistance.