### PR TITLE
dbeaver/pro#9627 Manage shared Maven plugin versions

### DIFF
--- a/root/pom.xml
+++ b/root/pom.xml
@@ -191,8 +191,18 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.11.0</version>
+                    <version>3.14.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.openapitools</groupId>
+                    <artifactId>openapi-generator-maven-plugin</artifactId>
+                    <version>0.0.32-dbeaver</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Superseded by #331.

## Summary
- manage assembly, compiler, and OpenAPI generator plugin versions in the shared parent POM
- update the managed compiler plugin version to 3.14.0

## Validation
- `./mvnw -N validate -DskipTests`
- downstream effective POM verification