### PR TITLE
dbeaver/pro#10435 Unify OAuth interactions

### DIFF
--- a/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/HttpConstants.java
+++ b/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/HttpConstants.java
@@ -37,6 +37,7 @@ public class HttpConstants {
     public static final String CONTENT_TYPE_JSON = "application/json";
     public static final String CONTENT_TYPE_APP_FORM = "application/x-www-form-urlencoded";
     public static final String CONTENT_TYPE_OCTET_STREAM = "application/octet-stream";
+    public static final String CONTENT_TYPE_TEXT_HTML = "text/html";
     public static final String CONTENT_TYPE_TEXT_PLAIN = "text/plain";
     public static final String CONTENT_TYPE_TEXT_XML = "text/xml";
     public static final String CONTENT_TYPE_CSV = "text/csv";
@@ -55,4 +56,5 @@ public class HttpConstants {
     public static final int CODE_SERVICE_UNAVAILABLE = 503;
 
     public static final String BEARER_PREFIX = "Bearer ";
+    public static final String BASIC_PREFIX = "Basic ";
 }

--- a/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/oauth/OAuthConstants.java
+++ b/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/oauth/OAuthConstants.java
@@ -26,9 +26,23 @@ public class OAuthConstants {
     public static final String AUTH_PROP_CLIENT_ID = "client_id";
     public static final String AUTH_PROP_CLIENT_SECRET = "client_secret";
     public static final String AUTH_PROP_TOKEN = "token";
+    public static final String PARAM_CODE = "code";
+    public static final String PARAM_CODE_CHALLENGE = "code_challenge";
+    public static final String PARAM_CODE_CHALLENGE_METHOD = "code_challenge_method";
+    public static final String PARAM_CODE_VERIFIER = "code_verifier";
+    public static final String PARAM_DEVICE_CODE = "device_code";
+    public static final String PARAM_ERROR = "error";
+    public static final String PARAM_ERROR_DESCRIPTION = "error_description";
+    public static final String PARAM_GRANT_TYPE = "grant_type";
+    public static final String PARAM_REDIRECT_URI = "redirect_uri";
+    public static final String PARAM_RESPONSE_TYPE = "response_type";
+    public static final String PARAM_SCOPE = "scope";
+    public static final String PARAM_STATE = "state";
     public static final String RESULT_PROP_TOKEN_ID = "id_token";
     public static final String GRANT_TYPE_CLIENT_CREDENTIALS = "client_credentials";
     public static final String GRANT_TYPE_AUTH_CODE = "authorization_code";
+    public static final String GRANT_TYPE_DEVICE_CODE = "urn:ietf:params:oauth:grant-type:device_code";
+    public static final String GRANT_TYPE_REFRESH_TOKEN = "refresh_token";
 
     public static final String RESPONSE_PARAM_ACCESS_TOKEN = "access_token";
     public static final String RESPONSE_PARAM_REFRESH_TOKEN = "refresh_token";

--- a/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/oauth/OAuthUtils.java
+++ b/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/oauth/OAuthUtils.java
@@ -41,6 +41,7 @@ import java.util.Map;
 public class OAuthUtils {
 
     public static final int TOKEN_VERIFIER_BYTE_LENGTH = 64;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     @NotNull
     public static String generateCodeVerifier() {
@@ -53,7 +54,7 @@ public class OAuthUtils {
             throw new IllegalArgumentException("Byte length must be positive");
         }
         byte[] bytes = new byte[byteLength];
-        new SecureRandom().nextBytes(bytes);
+        SECURE_RANDOM.nextBytes(bytes);
         return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     }
 

--- a/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/oauth/OAuthUtils.java
+++ b/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/oauth/OAuthUtils.java
@@ -29,11 +29,43 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.time.Duration;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 
 public class OAuthUtils {
+
+    public static final int TOKEN_VERIFIER_BYTE_LENGTH = 64;
+
+    @NotNull
+    public static String generateCodeVerifier() {
+        return generateRandomUrlSafeValue(TOKEN_VERIFIER_BYTE_LENGTH);
+    }
+
+    @NotNull
+    public static String generateRandomUrlSafeValue(int byteLength) {
+        if (byteLength <= 0) {
+            throw new IllegalArgumentException("Byte length must be positive");
+        }
+        byte[] bytes = new byte[byteLength];
+        new SecureRandom().nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    @NotNull
+    public static String generateCodeChallenge(@NotNull String verifier) throws IOException {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(verifier.getBytes(StandardCharsets.US_ASCII));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IOException("Missing SHA-256 algorithm", e);
+        }
+    }
 
     public static OAuthTokens refreshAccessToken(
         @NotNull String tokenEndpoint,
@@ -44,14 +76,14 @@ public class OAuthUtils {
     ) throws IOException {
 
         Map<String, String> tokenParams = new HashMap<>();
-        tokenParams.put("grant_type", "refresh_token");
-        tokenParams.put("client_id", clientId);
-        tokenParams.put("refresh_token", refreshToken);
-        tokenParams.put("scope", scope);
+        tokenParams.put(OAuthConstants.PARAM_GRANT_TYPE, OAuthConstants.GRANT_TYPE_REFRESH_TOKEN);
+        tokenParams.put(OAuthConstants.AUTH_PROP_CLIENT_ID, clientId);
+        tokenParams.put(OAuthConstants.RESPONSE_PARAM_REFRESH_TOKEN, refreshToken);
+        tokenParams.put(OAuthConstants.PARAM_SCOPE, scope);
 
         String tokenBody = OAuthRequestURLBuilder.buildURLParameters(tokenParams);
         HttpResponse<String> response = executePostRequest(tokenEndpoint, tokenBody, timeoutSec);
-        if (response.statusCode() == 200) {
+        if (response.statusCode() == HttpConstants.CODE_OK) {
             JsonObject jsonObject = JsonParser.parseString(response.body()).getAsJsonObject();
             if (jsonObject.has(OAuthConstants.RESPONSE_PARAM_ACCESS_TOKEN)) {
                 String accessToken = jsonObject.get(OAuthConstants.RESPONSE_PARAM_ACCESS_TOKEN).getAsString();

--- a/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/oauth/client/OAuthClientCredentialsHandler.java
+++ b/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/oauth/client/OAuthClientCredentialsHandler.java
@@ -79,12 +79,19 @@ public class OAuthClientCredentialsHandler implements IOAuthHandler {
             OAuthRequestPostBuilder requestBuilder = new OAuthRequestPostBuilder(authUrl)
                 .withClientId(clientId)
                 .withClientSecret(secretId)
-                .withGrantType(OAuthConstants.GRANT_TYPE_CLIENT_CREDENTIALS);
+                .withGrantType(OAuthConstants.GRANT_TYPE_CLIENT_CREDENTIALS)
+                .withTimeout(timeout);
             // Send POST
             try {
                 HttpResponse<String> response = client.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+                if (response.statusCode() / 100 != 2) {
+                    throw new IOException(
+                        "Authorization request failed. HTTP status: " + response.statusCode() + ", body: " + response.body()
+                    );
+                }
                 return extractResponse(response);
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new IOException("Authorization request interrupted", e);
             }
         } finally {

--- a/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/oauth/client/OAuthRequestPostBuilder.java
+++ b/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/oauth/client/OAuthRequestPostBuilder.java
@@ -18,17 +18,20 @@ package org.jkiss.utils.oauth.client;
 
 import org.jkiss.utils.CommonUtils;
 import org.jkiss.utils.HttpConstants;
+import org.jkiss.utils.oauth.OAuthConstants;
 
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpRequest;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 
 public class OAuthRequestPostBuilder {
     private URI tokenUri;
     private String clientId;
     private String grantType;
     private String clientSecret;
+    private int timeout;
 
     public OAuthRequestPostBuilder(String authUrl) {
         if (CommonUtils.isNotEmpty(authUrl)) {
@@ -55,13 +58,23 @@ public class OAuthRequestPostBuilder {
         return this;
     }
 
+    public OAuthRequestPostBuilder withTimeout(int timeout) {
+        this.timeout = timeout;
+        return this;
+    }
+
     public HttpRequest build() {
         HttpRequest.Builder builder = tokenUri == null ? HttpRequest.newBuilder() : HttpRequest.newBuilder(tokenUri);
-        return builder.POST(HttpRequest.BodyPublishers.ofString(
-                "&grant_type=" + URLEncoder.encode(grantType, StandardCharsets.UTF_8)
-        )).header(HttpConstants.HEADER_AUTHORIZATION, "Basic " +
-                java.util.Base64.getEncoder().encodeToString((clientId + ":" + clientSecret).getBytes(StandardCharsets.UTF_8)))
-                .header(HttpConstants.HEADER_CONTENT_TYPE, HttpConstants.CONTENT_TYPE_APP_FORM)
-                .build();
+        builder.POST(HttpRequest.BodyPublishers.ofString(
+                OAuthConstants.PARAM_GRANT_TYPE + "=" + URLEncoder.encode(grantType, StandardCharsets.UTF_8)
+        )).header(HttpConstants.HEADER_AUTHORIZATION, HttpConstants.BASIC_PREFIX +
+                java.util.Base64.getEncoder().encodeToString(
+                    (clientId + ":" + CommonUtils.notEmpty(clientSecret)).getBytes(StandardCharsets.UTF_8)
+                ))
+            .header(HttpConstants.HEADER_CONTENT_TYPE, HttpConstants.CONTENT_TYPE_APP_FORM);
+        if (timeout > 0) {
+            builder.timeout(Duration.ofSeconds(timeout));
+        }
+        return builder.build();
     }
 }

--- a/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/oauth/code/OAuthCodeHandler.java
+++ b/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/oauth/code/OAuthCodeHandler.java
@@ -24,6 +24,7 @@ import org.jkiss.utils.HttpConstants;
 import org.jkiss.utils.IOUtils;
 import org.jkiss.utils.oauth.IOAuthHandler;
 import org.jkiss.utils.oauth.OAuthConstants;
+import org.jkiss.utils.oauth.OAuthUtils;
 
 import java.awt.*;
 import java.io.IOException;
@@ -32,11 +33,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import java.time.Duration;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -54,8 +51,7 @@ public class OAuthCodeHandler implements IOAuthHandler {
         .setStrictness(Strictness.LENIENT)
         .setPrettyPrinting()
         .create();
-    public static final int TOKEN_VERIFIER_BYTE_LENGTH = 64;
-    private static final String GRANT_TYPE = "grant_type";
+    public static final int TOKEN_VERIFIER_BYTE_LENGTH = OAuthUtils.TOKEN_VERIFIER_BYTE_LENGTH;
 
     @NotNull
     protected final String clientId;
@@ -70,9 +66,10 @@ public class OAuthCodeHandler implements IOAuthHandler {
     protected final int callbackPort;
     @NotNull
     protected final String callbackEndpoint;
-    protected int timeout;
+    protected int timeout = OAuthConstants.AUTH_DEFAULT_SSO_TIMEOUT;
     @Nullable
     protected String state;
+    private boolean generatedState;
 
     @Nullable
     protected final String scope;
@@ -155,8 +152,13 @@ public class OAuthCodeHandler implements IOAuthHandler {
     @NotNull
     @Override
     public Map<String, String> authorize() throws IOException {
+        if (state == null || generatedState) {
+            state = OAuthUtils.generateRandomUrlSafeValue(32);
+            generatedState = true;
+        }
         try (IOAuthCodeResponseHandler handler = createCodeResponseHandler()) {
-            String verifier = generateCodeChallengeAndVerifier();
+            String verifier = OAuthUtils.generateCodeVerifier();
+            codeChallenge = OAuthUtils.generateCodeChallenge(verifier);
             startSSO(handler);
             String code = handler.requestCode().get(timeout, TimeUnit.SECONDS);
 
@@ -179,7 +181,10 @@ public class OAuthCodeHandler implements IOAuthHandler {
             } finally {
                 IOUtils.tryClose(client);
             }
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException(e);
+        } catch (ExecutionException | TimeoutException e) {
             throw new IOException(e);
         }
     }
@@ -191,6 +196,7 @@ public class OAuthCodeHandler implements IOAuthHandler {
 
     @NotNull
     protected IOAuthCodeResponseHandler createCodeResponseHandler() {
+        // Keep state validation opt-in for subclasses that build their own authorization URL.
         return new OAuthCodeResponseHandler(callbackPort, callbackEndpoint);
     }
 
@@ -240,38 +246,6 @@ public class OAuthCodeHandler implements IOAuthHandler {
     }
 
     /**
-     * Generates a code verifier and corresponding code challenge using SHA-256.
-     *
-     * @return the code verifier
-     * @throws IOException if SHA-256 algorithm is not available
-     */
-    @NotNull
-    private String generateCodeChallengeAndVerifier() throws IOException {
-        String codeVerifier = generateVerifier();
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] shaEncode = digest.digest(codeVerifier.getBytes());
-            codeChallenge = Base64.getUrlEncoder().withoutPadding().encodeToString(shaEncode);
-        } catch (NoSuchAlgorithmException e) {
-            throw new IOException("Missing SHA-256 algorithm");
-        }
-        return codeVerifier;
-    }
-
-    /**
-     * Generates a random code verifier as a URL-safe Base64 string.
-     *
-     * @return a new code verifier
-     */
-    @NotNull
-    private static String generateVerifier() {
-        SecureRandom secureRandom = new SecureRandom();
-        byte[] secureValue = new byte[TOKEN_VERIFIER_BYTE_LENGTH];
-        secureRandom.nextBytes(secureValue);
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(secureValue);
-    }
-
-    /**
      * Builds the form parameters for the token request including verifier and redirect URI.
      *
      * @param code     the authorization code received from the server
@@ -284,15 +258,15 @@ public class OAuthCodeHandler implements IOAuthHandler {
         @NotNull String verifier
     ) {
         Map<String, String> parameters = new HashMap<>();
-        parameters.put(GRANT_TYPE, OAuthConstants.GRANT_TYPE_AUTH_CODE);
-        parameters.put("code", code);
+        parameters.put(OAuthConstants.PARAM_GRANT_TYPE, OAuthConstants.GRANT_TYPE_AUTH_CODE);
+        parameters.put(OAuthConstants.PARAM_CODE, code);
         parameters.put(OAuthConstants.AUTH_PROP_CLIENT_ID, clientId);
         if (CommonUtils.isNotEmpty(secretId)) {
             parameters.put(OAuthConstants.AUTH_PROP_CLIENT_SECRET, secretId);
         }
-        parameters.put("code_verifier", verifier);
+        parameters.put(OAuthConstants.PARAM_CODE_VERIFIER, verifier);
         parameters.put(
-            "redirect_uri",
+            OAuthConstants.PARAM_REDIRECT_URI,
             getRedirectUri()
         );
         return OAuthRequestURLBuilder.buildURLParameters(parameters);
@@ -313,6 +287,9 @@ public class OAuthCodeHandler implements IOAuthHandler {
         }
         if (CommonUtils.isNotEmpty(scope)) {
             builder.withScope(scope);
+        }
+        if (state != null) {
+            builder.withState(state);
         }
         return builder.build();
     }

--- a/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/oauth/code/OAuthCodeHandler.java
+++ b/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/oauth/code/OAuthCodeHandler.java
@@ -21,6 +21,7 @@ import org.jkiss.code.NotNull;
 import org.jkiss.code.Nullable;
 import org.jkiss.utils.CommonUtils;
 import org.jkiss.utils.HttpConstants;
+import org.jkiss.utils.HttpUtils;
 import org.jkiss.utils.IOUtils;
 import org.jkiss.utils.oauth.IOAuthHandler;
 import org.jkiss.utils.oauth.OAuthConstants;
@@ -196,8 +197,7 @@ public class OAuthCodeHandler implements IOAuthHandler {
 
     @NotNull
     protected IOAuthCodeResponseHandler createCodeResponseHandler() {
-        // Keep state validation opt-in for subclasses that build their own authorization URL.
-        return new OAuthCodeResponseHandler(callbackPort, callbackEndpoint);
+        return new OAuthCodeResponseHandler(callbackPort, callbackEndpoint, state);
     }
 
     /**
@@ -228,7 +228,13 @@ public class OAuthCodeHandler implements IOAuthHandler {
      */
     protected void startSSO(@NotNull IOAuthCodeResponseHandler handler) throws IOException {
         handler.initServer();
-        createBrowser(buildAuthUrl());
+        String authorizationUrl = buildAuthUrl();
+        URI uri = URI.create(authorizationUrl);
+        if (!HttpUtils.parseQuery(uri.getRawQuery()).containsKey(OAuthConstants.PARAM_STATE)) {
+            authorizationUrl += (uri.getRawQuery() == null ? "?" : "&")
+                + OAuthRequestURLBuilder.buildURLParameters(Map.of(OAuthConstants.PARAM_STATE, state));
+        }
+        createBrowser(authorizationUrl);
     }
 
     /**

--- a/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/oauth/code/OAuthCodeResponseHandler.java
+++ b/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/oauth/code/OAuthCodeResponseHandler.java
@@ -18,36 +18,42 @@ package org.jkiss.utils.oauth.code;
 
 import com.sun.net.httpserver.HttpServer;
 import org.jkiss.code.NotNull;
+import org.jkiss.code.Nullable;
 import org.jkiss.utils.CommonUtils;
 import org.jkiss.utils.HttpConstants;
 import org.jkiss.utils.HttpUtils;
+import org.jkiss.utils.oauth.OAuthConstants;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Handles the temporary HTTP server that listens for OAuth callback requests.
  * Extracts the authorization code or error from the query string and returns it to the caller.
  */
 public class OAuthCodeResponseHandler implements IOAuthCodeResponseHandler {
-
-    private static final String PARAM_CODE = "code";
-    private static final String PARAM_ERROR = "error";
     private static final String SUCCESSFUL_ANSWER_FOR_AUTH = "Auth has been completed";
     private static final String FAILED_ANSWER_FOR_AUTH = "Errors encountered during authorization";
 
     private final int port;
     @NotNull
     private final String callbackEndpoint;
-
-    private volatile boolean notShutDown;
-    private HttpServer httpServer;
-    private final ExecutorService clientExecutor = Executors.newSingleThreadExecutor();
+    @Nullable
+    private final String expectedState;
+    @NotNull
+    private final CompletableFuture<String> authorizationCode = new CompletableFuture<>();
+    @NotNull
     private final ThreadPoolExecutor serverExecutor;
+
+    @Nullable
+    private HttpServer httpServer;
 
     /**
      * Creates a new instance of the response handler.
@@ -56,8 +62,16 @@ public class OAuthCodeResponseHandler implements IOAuthCodeResponseHandler {
      * @param callbackEndpoint the expected endpoint path (e.g. "/callback")
      */
     public OAuthCodeResponseHandler(int port, @NotNull String callbackEndpoint) {
+        this(port, callbackEndpoint, null);
+    }
+
+    /**
+     * Creates a response handler that validates the state returned by the authorization server.
+     */
+    public OAuthCodeResponseHandler(int port, @NotNull String callbackEndpoint, @Nullable String expectedState) {
         this.port = port;
         this.callbackEndpoint = callbackEndpoint;
+        this.expectedState = expectedState;
         this.serverExecutor = new ThreadPoolExecutor(
             1,
             10,
@@ -68,98 +82,91 @@ public class OAuthCodeResponseHandler implements IOAuthCodeResponseHandler {
     }
 
     /**
-     * Initializes the HTTP server on a free port.
-     * The server is configured with a thread pool and started immediately.
+     * Initializes the callback server on the loopback interface.
      *
-     * @throws IOException if the server cannot be created or bound to the selected port.
+     * @throws IOException if the server cannot be created or bound to the selected port
      */
     @Override
     public void initServer() throws IOException {
         try {
-            httpServer = HttpServer.create(new InetSocketAddress(port), 1);
+            httpServer = HttpServer.create(new InetSocketAddress("localhost", port), 1);
         } catch (IOException e) {
             throw new IOException("Can't create callback server", e);
         }
         httpServer.setExecutor(serverExecutor);
+        httpServer.createContext(callbackEndpoint, exchange -> {
+            Map<String, String> params = HttpUtils.parseQuery(exchange.getRequestURI().getRawQuery());
+            String code = params.get(OAuthConstants.PARAM_CODE);
+            String error = params.get(OAuthConstants.PARAM_ERROR);
+            String answer;
+            int statusCode;
+            String receivedCode = null;
+            IOException failure = null;
+            if (expectedState != null && !expectedState.equals(params.get(OAuthConstants.PARAM_STATE))) {
+                answer = FAILED_ANSWER_FOR_AUTH;
+                statusCode = HttpConstants.CODE_BAD_REQUEST;
+            } else if (CommonUtils.isNotEmpty(error)) {
+                httpServer.removeContext(callbackEndpoint);
+                String description = params.get(OAuthConstants.PARAM_ERROR_DESCRIPTION);
+                failure = new IOException(
+                    "Error receiving code " + (CommonUtils.isNotEmpty(description) ? description : error)
+                );
+                answer = FAILED_ANSWER_FOR_AUTH;
+                statusCode = HttpConstants.CODE_OK;
+            } else if (CommonUtils.isNotEmpty(code)) {
+                httpServer.removeContext(callbackEndpoint);
+                receivedCode = code;
+                answer = SUCCESSFUL_ANSWER_FOR_AUTH;
+                statusCode = HttpConstants.CODE_OK;
+            } else {
+                httpServer.removeContext(callbackEndpoint);
+                failure = new IOException("OAuth callback does not contain authorization code");
+                answer = FAILED_ANSWER_FOR_AUTH;
+                statusCode = HttpConstants.CODE_BAD_REQUEST;
+            }
+
+            byte[] response = answer.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set(
+                HttpConstants.HEADER_CONTENT_TYPE,
+                HttpConstants.CONTENT_TYPE_TEXT_PLAIN + "; charset=UTF-8"
+            );
+            exchange.sendResponseHeaders(statusCode, response.length);
+            try (var body = exchange.getResponseBody()) {
+                body.write(response);
+            }
+            if (receivedCode != null) {
+                authorizationCode.complete(receivedCode);
+            } else if (failure != null) {
+                authorizationCode.completeExceptionally(failure);
+            }
+        });
         httpServer.start();
     }
 
-    /**
-     * Submits a request to wait for an OAuth authorization code via HTTP callback.
-     * The method creates a temporary HTTP context that listens for a request containing
-     * either an authorization code or an error. The code is extracted from the query string.
-     *
-     * @return a {@link Future} containing the received authorization code, or throws an exception if an error occurred.
-     */
     @NotNull
     @Override
     public Future<String> requestCode() {
-        notShutDown = true;
-        return clientExecutor.submit(() -> {
-            AtomicReference<String> result = new AtomicReference<>();
-            AtomicBoolean hasErrors = new AtomicBoolean(false);
-            httpServer.createContext(
-                callbackEndpoint, exchange -> {
-                    String query = exchange.getRequestURI().getQuery();
-                    String answer;
-                    Map<String, String> params = HttpUtils.parseQuery(query);
-                    String code = params.get(PARAM_CODE);
-                    if (CommonUtils.isNotEmpty(code)) {
-                        result.set(code);
-                        answer = SUCCESSFUL_ANSWER_FOR_AUTH;
-                    } else {
-                        hasErrors.set(true);
-                        String error = params.get(PARAM_ERROR);
-                        if (CommonUtils.isNotEmpty(error)) {
-                            result.set(error);
-                        }
-                        answer = FAILED_ANSWER_FOR_AUTH;
-                    }
+        return authorizationCode;
+    }
 
-                    exchange.sendResponseHeaders(HttpConstants.CODE_OK, answer.getBytes().length);
-                    exchange.getResponseBody().write(answer.getBytes());
-                    exchange.close();
-                }
-            );
-            while (result.get() == null && notShutDown) {
-                Thread.onSpinWait();
-            }
+    @Override
+    public void addStabContext() {
+        if (httpServer == null) {
+            return;
+        }
+        httpServer.createContext(callbackEndpoint, exchange -> {
+            exchange.sendResponseHeaders(HttpConstants.CODE_OK, 0);
             httpServer.removeContext(callbackEndpoint);
-            if (hasErrors.get()) {
-                throw new IOException("Error receiving code " + result.get());
-            }
-            return result.get();
+            exchange.close();
         });
     }
 
-    /**
-     * Adds a temporary HTTP context at the callback endpoint to respond with a 200 OK
-     * and immediately removes itself. This is typically used as a stub or placeholder context.
-     */
     @Override
-    public void addStabContext() {
-        httpServer.createContext(
-            callbackEndpoint, exchange -> {
-                exchange.sendResponseHeaders(HttpConstants.CODE_OK, 0);
-                httpServer.removeContext(callbackEndpoint);
-                exchange.close();
-            }
-        );
-    }
-
-    /**
-     * Stops the HTTP server and releases resources.
-     *
-     * @throws IOException if the server fails to stop
-     */
-    @Override
-    public void close() throws IOException {
+    public void close() {
+        authorizationCode.cancel(false);
         if (httpServer != null) {
             httpServer.stop(0);
         }
-        clientExecutor.shutdown();
-        serverExecutor.shutdown();
-        notShutDown = false;
+        serverExecutor.shutdownNow();
     }
-
 }

--- a/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/oauth/code/OAuthCodeResponseHandler.java
+++ b/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/oauth/code/OAuthCodeResponseHandler.java
@@ -28,11 +28,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 /**
  * Handles the temporary HTTP server that listens for OAuth callback requests.
@@ -47,6 +43,8 @@ public class OAuthCodeResponseHandler implements IOAuthCodeResponseHandler {
     private final String callbackEndpoint;
     @Nullable
     private final String expectedState;
+    @Nullable
+    private final String successHtml;
     @NotNull
     private final CompletableFuture<String> authorizationCode = new CompletableFuture<>();
     @NotNull
@@ -69,9 +67,22 @@ public class OAuthCodeResponseHandler implements IOAuthCodeResponseHandler {
      * Creates a response handler that validates the state returned by the authorization server.
      */
     public OAuthCodeResponseHandler(int port, @NotNull String callbackEndpoint, @Nullable String expectedState) {
+        this(port, callbackEndpoint, expectedState, null);
+    }
+
+    /**
+     * Creates a response handler that returns the supplied HTML after successful authorization.
+     */
+    public OAuthCodeResponseHandler(
+        int port,
+        @NotNull String callbackEndpoint,
+        @Nullable String expectedState,
+        @Nullable String successHtml
+    ) {
         this.port = port;
         this.callbackEndpoint = callbackEndpoint;
         this.expectedState = expectedState;
+        this.successHtml = successHtml;
         this.serverExecutor = new ThreadPoolExecutor(
             1,
             10,
@@ -116,7 +127,7 @@ public class OAuthCodeResponseHandler implements IOAuthCodeResponseHandler {
             } else if (CommonUtils.isNotEmpty(code)) {
                 httpServer.removeContext(callbackEndpoint);
                 receivedCode = code;
-                answer = SUCCESSFUL_ANSWER_FOR_AUTH;
+                answer = successHtml == null ? SUCCESSFUL_ANSWER_FOR_AUTH : successHtml;
                 statusCode = HttpConstants.CODE_OK;
             } else {
                 httpServer.removeContext(callbackEndpoint);
@@ -128,7 +139,9 @@ public class OAuthCodeResponseHandler implements IOAuthCodeResponseHandler {
             byte[] response = answer.getBytes(StandardCharsets.UTF_8);
             exchange.getResponseHeaders().set(
                 HttpConstants.HEADER_CONTENT_TYPE,
-                HttpConstants.CONTENT_TYPE_TEXT_PLAIN + "; charset=UTF-8"
+                successHtml != null && receivedCode != null
+                    ? HttpConstants.CONTENT_TYPE_TEXT_HTML + "; charset=UTF-8"
+                    : HttpConstants.CONTENT_TYPE_TEXT_PLAIN + "; charset=UTF-8"
             );
             exchange.sendResponseHeaders(statusCode, response.length);
             try (var body = exchange.getResponseBody()) {

--- a/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/oauth/code/OAuthRequestURLBuilder.java
+++ b/modules/org.jkiss.utils/src/main/java/org/jkiss/utils/oauth/code/OAuthRequestURLBuilder.java
@@ -203,7 +203,6 @@ public class OAuthRequestURLBuilder {
         }
 
         if (includeState) {
-            // TODO: we must validate state on callback
             params.putIfAbsent("state", state == null ? UUID.randomUUID().toString() : state);
         }
 
@@ -215,7 +214,7 @@ public class OAuthRequestURLBuilder {
             params.put("scope", "openid email profile");
         }
 
-        return baseURL + "?" + buildURLParameters(params);
+        return baseURL + (baseURL.contains("?") ? "&" : "?") + buildURLParameters(params);
     }
 
     public static String buildURLParameters(Map<String, String> params) {

--- a/modules/org.jkiss.utils/src/test/java/org/jkiss/utils/oauth/OAuthUtilsTest.java
+++ b/modules/org.jkiss.utils/src/test/java/org/jkiss/utils/oauth/OAuthUtilsTest.java
@@ -1,0 +1,47 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.utils.oauth;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class OAuthUtilsTest {
+    @Test
+    void generatesKnownPkceChallenge() throws IOException {
+        assertEquals(
+            "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+            OAuthUtils.generateCodeChallenge("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")
+        );
+    }
+
+    @Test
+    void generatesUrlSafeVerifier() {
+        String verifier = OAuthUtils.generateCodeVerifier();
+        assertEquals(86, verifier.length());
+        assertFalse(verifier.contains("="));
+    }
+
+    @Test
+    void rejectsEmptyRandomValue() {
+        assertThrows(IllegalArgumentException.class, () -> OAuthUtils.generateRandomUrlSafeValue(0));
+    }
+}

--- a/modules/org.jkiss.utils/src/test/java/org/jkiss/utils/oauth/client/OAuthRequestPostBuilderTest.java
+++ b/modules/org.jkiss.utils/src/test/java/org/jkiss/utils/oauth/client/OAuthRequestPostBuilderTest.java
@@ -1,0 +1,41 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.utils.oauth.client;
+
+import org.jkiss.utils.HttpConstants;
+import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpRequest;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class OAuthRequestPostBuilderTest {
+    @Test
+    void buildsClientCredentialsRequest() {
+        HttpRequest request = new OAuthRequestPostBuilder("https://example.com/token")
+            .withClientId("client")
+            .withClientSecret(null)
+            .withGrantType("client_credentials")
+            .withTimeout(30)
+            .build();
+
+        assertEquals(29, request.bodyPublisher().orElseThrow().contentLength());
+        assertEquals("Basic Y2xpZW50Og==", request.headers().firstValue(HttpConstants.HEADER_AUTHORIZATION).orElseThrow());
+        assertEquals(Duration.ofSeconds(30), request.timeout().orElseThrow());
+    }
+}

--- a/modules/org.jkiss.utils/src/test/java/org/jkiss/utils/oauth/code/OAuthCodeHandlerTest.java
+++ b/modules/org.jkiss.utils/src/test/java/org/jkiss/utils/oauth/code/OAuthCodeHandlerTest.java
@@ -1,0 +1,84 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.utils.oauth.code;
+
+import org.jkiss.code.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class OAuthCodeHandlerTest {
+    @Test
+    void addsStateToCustomAuthorizationUrl() throws IOException {
+        TestOAuthCodeHandler handler = new TestOAuthCodeHandler();
+
+        handler.startSSO(new NoOpResponseHandler());
+
+        assertEquals("https://example.com/authorize?custom=value&state=expected", handler.openedUrl);
+    }
+
+    private static class TestOAuthCodeHandler extends OAuthCodeHandler {
+        private String openedUrl;
+
+        private TestOAuthCodeHandler() {
+            super(
+                "client",
+                null,
+                "https://example.com/authorize",
+                "https://example.com/token",
+                "/callback",
+                "http://localhost/callback",
+                0
+            );
+            state = "expected";
+        }
+
+        @Override
+        protected String buildAuthUrl() {
+            return "https://example.com/authorize?custom=value";
+        }
+
+        @Override
+        protected void createBrowser(@NotNull String url) {
+            openedUrl = url;
+        }
+    }
+
+    private static class NoOpResponseHandler implements IOAuthCodeResponseHandler {
+        @Override
+        public void initServer() {
+        }
+
+        @NotNull
+        @Override
+        public Future<String> requestCode() {
+            return new CompletableFuture<>();
+        }
+
+        @Override
+        public void addStabContext() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/modules/org.jkiss.utils/src/test/java/org/jkiss/utils/oauth/code/OAuthCodeResponseHandlerTest.java
+++ b/modules/org.jkiss.utils/src/test/java/org/jkiss/utils/oauth/code/OAuthCodeResponseHandlerTest.java
@@ -42,6 +42,23 @@ class OAuthCodeResponseHandlerTest {
     }
 
     @Test
+    void returnsCustomSuccessHtml() throws Exception {
+        int port = getFreePort();
+        String successHtml = "<html><body>Authentication complete</body></html>";
+        try (OAuthCodeResponseHandler handler =
+                 new OAuthCodeResponseHandler(port, "/callback", "expected", successHtml)) {
+            handler.initServer();
+
+            HttpResponse<String> response = sendCallback(port, "?code=auth-code&state=expected");
+
+            assertEquals(200, response.statusCode());
+            assertEquals("text/html; charset=UTF-8", response.headers().firstValue("Content-Type").orElseThrow());
+            assertEquals(successHtml, response.body());
+            assertEquals("auth-code", handler.requestCode().get(1, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
     void ignoresUnexpectedState() throws Exception {
         int port = getFreePort();
         try (OAuthCodeResponseHandler handler = new OAuthCodeResponseHandler(port, "/callback", "expected")) {

--- a/modules/org.jkiss.utils/src/test/java/org/jkiss/utils/oauth/code/OAuthCodeResponseHandlerTest.java
+++ b/modules/org.jkiss.utils/src/test/java/org/jkiss/utils/oauth/code/OAuthCodeResponseHandlerTest.java
@@ -1,0 +1,70 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jkiss.utils.oauth.code;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class OAuthCodeResponseHandlerTest {
+    @Test
+    void returnsAuthorizationCode() throws Exception {
+        int port = getFreePort();
+        try (OAuthCodeResponseHandler handler = new OAuthCodeResponseHandler(port, "/callback", "expected")) {
+            handler.initServer();
+
+            HttpResponse<String> response = sendCallback(port, "?code=auth-code&state=expected");
+
+            assertEquals(200, response.statusCode());
+            assertEquals("auth-code", handler.requestCode().get(1, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void ignoresUnexpectedState() throws Exception {
+        int port = getFreePort();
+        try (OAuthCodeResponseHandler handler = new OAuthCodeResponseHandler(port, "/callback", "expected")) {
+            handler.initServer();
+
+            HttpResponse<String> rejected = sendCallback(port, "?code=stale-code&state=unexpected");
+            sendCallback(port, "?code=auth-code&state=expected");
+
+            assertEquals(400, rejected.statusCode());
+            assertEquals("auth-code", handler.requestCode().get(1, TimeUnit.SECONDS));
+        }
+    }
+
+    private static HttpResponse<String> sendCallback(int port, String query) throws Exception {
+        return HttpClient.newHttpClient().send(
+            HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/callback" + query)).GET().build(),
+            HttpResponse.BodyHandlers.ofString()
+        );
+    }
+
+    private static int getFreePort() throws Exception {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}


### PR DESCRIPTION
Closes dbeaver/pro#10435

## Summary
- centralize OAuth parameters, PKCE generation, and HTTP constants
- make callback handling state-aware, loopback-only, race-free, and reusable
- harden authorization-code and client-credentials handlers

## Tests
- `./mvnw -pl :org.jkiss.utils -am test` (120 tests passed)

This PR was generated with AI.