### PR TITLE
dbeaver/pro#10646 Migrate to Eclipse 2026-09

### DIFF
--- a/root/pom.xml
+++ b/root/pom.xml
@@ -20,7 +20,7 @@
         <dbeaver-version>26.2.1</dbeaver-version>
 
         <tycho-version>5.0.4</tycho-version>
-        <eclipse-version>2026-06</eclipse-version>
+        <eclipse-version>2026-09</eclipse-version>
 
         <maven>3.9.16</maven>
         <maven-version>${maven}</maven-version>


### PR DESCRIPTION
Closes dbeaver/pro#10646

Updates the shared Eclipse release repository to 2026-09 (4.41).

Companion changes: dbeaver/dbeaver#42070.

Validation:
- .\mvnw.cmd clean verify (121 tests passed)
- Full DBeaver CE aggregate build against Eclipse 2026-09

This PR was generated with AI (OpenCode).