### PR TITLE
dbeaver/cloudbeaver#4650 Update Spring Boot dependencies

### DIFF
--- a/root/pom.xml
+++ b/root/pom.xml
@@ -52,7 +52,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
 
-        <spring.boot.version>4.1.0</spring.boot.version>
+        <spring.boot.version>4.1.1</spring.boot.version>
         <jetty.version>12.1.11</jetty.version>
         <clickhouse.jdbc.version>0.8.5</clickhouse.jdbc.version>
         <google.gson.version>2.14.0</google.gson.version>


### PR DESCRIPTION
Closes dbeaver/cloudbeaver#4650

## Summary
- update Spring Boot dependency management from 4.1.0 to 4.1.1
- update Spring Framework to 7.0.9 and Spring Security to 7.1.1
- keep Jetty on the already patched 12.1.11 version

## Testing
- .\mvnw.cmd -pl modules/com.dbeaver.spring.utils -am verify
- verified CloudBeaver microservice dependency trees resolve the patched Spring versions

This PR was generated with AI assistance.