### PR TITLE
dbeaver/pro#10683 Allow static imports in tests

### DIFF
--- a/.github/dbeaver-checkstyle-config.xml
+++ b/.github/dbeaver-checkstyle-config.xml
@@ -33,6 +33,10 @@
            default="checkstyle-suppressions.xml" />
     <property name="optional" value="true"/>
   </module>
+  <module name="SuppressionSingleFilter">
+    <property name="files" value="[/\\]src[/\\]test[/\\]"/>
+    <property name="checks" value="AvoidStaticImport"/>
+  </module>
 
   <!-- Checks for whitespace                               -->
   <!-- See http://checkstyle.org/config_whitespace.html -->


### PR DESCRIPTION
Closes dbeaver/pro#10683

## Summary
- Suppress AvoidStaticImport for files under src/test/ in the shared Checkstyle configuration.
- Support both Unix and Windows path separators.
- Preserve static-import warnings in production sources and all other checks, including import ordering.

## Validation
- Ran seven regression scenarios against Checkstyle 10.21.4 (the CI version), comparing diagnostics before and after the change.
- Verified test sources, integration-test naming, Windows-style paths, production sources, and similarly named non-test paths.
- git diff --check passed.